### PR TITLE
Adding Apple App Store node

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,5 +203,6 @@ Community nodes built with this template:
 | **Hypebridge Actors** | [n8n-nodes-hypebridge-actors](https://www.npmjs.com/package/n8n-nodes-hypebridge-actors) | [hypebridge](https://apify.com/hypebridge) |
 | **TikTok Scraper Ultimate** | [n8n-nodes-tiktok-scraper-ultimate](https://www.npmjs.com/package/n8n-nodes-tiktok-scraper-ultimate) | [novi](https://apify.com/novi) |
 | **TheirStack Actor** | [n8n-nodes-theirstack-actor](https://www.npmjs.com/package/n8n-nodes-theirstack-actor) | [ernesta_labs](https://apify.com/ernesta_labs) |
+| **Apple App Store** | [n8n-nodes-apple-app-store-api](https://www.npmjs.com/package/n8n-nodes-apple-app-store-api) | [johnvc](https://apify.com/johnvc) |
 
 Built a node with this template? Open a PR to add it to the list!


### PR DESCRIPTION
Adds the **Apple App Store** community node to the Published Nodes list.

One node with three operations, backed by Apify Actors:
- **Review > Get Many** reviews for any iOS or macOS app (by name or Apple ID)
- **App > Search** the App Store by keyword
- **App > Get** full product details by ID or URL

npm: https://www.npmjs.com/package/n8n-nodes-apple-app-store-api