### PR TITLE
Adding Fuel Prices Actor

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,5 +203,6 @@ Community nodes built with this template:
 | **Hypebridge Actors** | [n8n-nodes-hypebridge-actors](https://www.npmjs.com/package/n8n-nodes-hypebridge-actors) | [hypebridge](https://apify.com/hypebridge) |
 | **TikTok Scraper Ultimate** | [n8n-nodes-tiktok-scraper-ultimate](https://www.npmjs.com/package/n8n-nodes-tiktok-scraper-ultimate) | [novi](https://apify.com/novi) |
 | **TheirStack Actor** | [n8n-nodes-theirstack-actor](https://www.npmjs.com/package/n8n-nodes-theirstack-actor) | [ernesta_labs](https://apify.com/ernesta_labs) |
+| **Fuel Prices** | [n8n-nodes-fuel-prices-api](https://www.npmjs.com/package/n8n-nodes-fuel-prices-api) | [johnvc](https://apify.com/johnvc) |
 
 Built a node with this template? Open a PR to add it to the list!


### PR DESCRIPTION
Adds the **Fuel Prices** community node to the Published Nodes table.

- npm: https://www.npmjs.com/package/n8n-nodes-fuel-prices-api
- Apify Actor: https://apify.com/johnvc/fuelprices

Real-time US gas station fuel prices by ZIP, city, or coordinates. Built with this template, published with provenance via npm trusted publishing, and passes `@n8n/scan-community-package`. Works as a regular node and as an AI Agent tool.