### PR TITLE
Adding 8 published nodes (Workday Jobs + Career Sites, Tripadvisor, Google Lens, Walmart, Google Play, Bing Search, Image Similarity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,5 +243,10 @@ Community nodes built with this template:
 | **Google Local Services** | [n8n-nodes-google-local-services-api](https://www.npmjs.com/package/n8n-nodes-google-local-services-api) | [johnvc](https://apify.com/johnvc) |
 | **Workday Jobs Actor** | [n8n-nodes-workday-jobs-api](https://www.npmjs.com/package/n8n-nodes-workday-jobs-api) | [johnvc](https://apify.com/johnvc) |
 | **Workday Career Sites Actor** | [n8n-nodes-workday-career-sites-api](https://www.npmjs.com/package/n8n-nodes-workday-career-sites-api) | [johnvc](https://apify.com/johnvc) |
+| **Tripadvisor Actor** | [n8n-nodes-tripadvisor-api](https://www.npmjs.com/package/n8n-nodes-tripadvisor-api) | [johnvc](https://apify.com/johnvc) |
+| **Google Lens Actor** | [n8n-nodes-google-lens-api](https://www.npmjs.com/package/n8n-nodes-google-lens-api) | [johnvc](https://apify.com/johnvc) |
+| **Walmart Actor** | [n8n-nodes-walmart-api](https://www.npmjs.com/package/n8n-nodes-walmart-api) | [johnvc](https://apify.com/johnvc) |
+| **Google Play Actor** | [n8n-nodes-google-play-api](https://www.npmjs.com/package/n8n-nodes-google-play-api) | [johnvc](https://apify.com/johnvc) |
+| **Bing Search Actor** | [n8n-nodes-bing-search-api](https://www.npmjs.com/package/n8n-nodes-bing-search-api) | [johnvc](https://apify.com/johnvc) |
 
 Built a node with this template? Open a PR to add it to the list!

--- a/README.md
+++ b/README.md
@@ -241,5 +241,6 @@ Community nodes built with this template:
 | **Earnings Call Transcript & SEC Filings** | [n8n-nodes-earnings-call-transcript-api](https://www.npmjs.com/package/n8n-nodes-earnings-call-transcript-api) | [johnvc](https://apify.com/johnvc) |
 | **Bing Copilot AI Answers** | [n8n-nodes-bing-copilot-api](https://www.npmjs.com/package/n8n-nodes-bing-copilot-api) | [johnvc](https://apify.com/johnvc) |
 | **Google Local Services** | [n8n-nodes-google-local-services-api](https://www.npmjs.com/package/n8n-nodes-google-local-services-api) | [johnvc](https://apify.com/johnvc) |
+| **Workday Jobs Actor** | [n8n-nodes-workday-jobs-api](https://www.npmjs.com/package/n8n-nodes-workday-jobs-api) | [johnvc](https://apify.com/johnvc) |
 
 Built a node with this template? Open a PR to add it to the list!

--- a/README.md
+++ b/README.md
@@ -248,5 +248,6 @@ Community nodes built with this template:
 | **Walmart Actor** | [n8n-nodes-walmart-api](https://www.npmjs.com/package/n8n-nodes-walmart-api) | [johnvc](https://apify.com/johnvc) |
 | **Google Play Actor** | [n8n-nodes-google-play-api](https://www.npmjs.com/package/n8n-nodes-google-play-api) | [johnvc](https://apify.com/johnvc) |
 | **Bing Search Actor** | [n8n-nodes-bing-search-api](https://www.npmjs.com/package/n8n-nodes-bing-search-api) | [johnvc](https://apify.com/johnvc) |
+| **Image Similarity Actor** | [n8n-nodes-image-similarity-api](https://www.npmjs.com/package/n8n-nodes-image-similarity-api) | [johnvc](https://apify.com/johnvc) |
 
 Built a node with this template? Open a PR to add it to the list!

--- a/README.md
+++ b/README.md
@@ -242,5 +242,6 @@ Community nodes built with this template:
 | **Bing Copilot AI Answers** | [n8n-nodes-bing-copilot-api](https://www.npmjs.com/package/n8n-nodes-bing-copilot-api) | [johnvc](https://apify.com/johnvc) |
 | **Google Local Services** | [n8n-nodes-google-local-services-api](https://www.npmjs.com/package/n8n-nodes-google-local-services-api) | [johnvc](https://apify.com/johnvc) |
 | **Workday Jobs Actor** | [n8n-nodes-workday-jobs-api](https://www.npmjs.com/package/n8n-nodes-workday-jobs-api) | [johnvc](https://apify.com/johnvc) |
+| **Workday Career Sites Actor** | [n8n-nodes-workday-career-sites-api](https://www.npmjs.com/package/n8n-nodes-workday-career-sites-api) | [johnvc](https://apify.com/johnvc) |
 
 Built a node with this template? Open a PR to add it to the list!


### PR DESCRIPTION
Adds eight published community nodes to the Published Nodes table, all Apify-backed, published to npm with provenance via trusted publishing:

- n8n-nodes-workday-jobs-api
- n8n-nodes-workday-career-sites-api
- n8n-nodes-tripadvisor-api
- n8n-nodes-google-lens-api
- n8n-nodes-walmart-api
- n8n-nodes-google-play-api
- n8n-nodes-bing-search-api
- n8n-nodes-image-similarity-api

Each row links the npm package and the Apify author profile, matching the existing table format.