### PR TITLE
Adding Wellfound Jobs and NFX Signal Investor Actors

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,5 +250,6 @@ Community nodes built with this template:
 | **Bing Search Actor** | [n8n-nodes-bing-search-api](https://www.npmjs.com/package/n8n-nodes-bing-search-api) | [johnvc](https://apify.com/johnvc) |
 | **Image Similarity Actor** | [n8n-nodes-image-similarity-api](https://www.npmjs.com/package/n8n-nodes-image-similarity-api) | [johnvc](https://apify.com/johnvc) |
 | **Wellfound Jobs Actor** | [n8n-nodes-wellfound-jobs-api](https://www.npmjs.com/package/n8n-nodes-wellfound-jobs-api) | [johnvc](https://apify.com/johnvc) |
+| **NFX Signal Investor Actor** | [n8n-nodes-nfx-signal-investor-api](https://www.npmjs.com/package/n8n-nodes-nfx-signal-investor-api) | [johnvc](https://apify.com/johnvc) |
 
 Built a node with this template? Open a PR to add it to the list!

--- a/README.md
+++ b/README.md
@@ -249,5 +249,6 @@ Community nodes built with this template:
 | **Google Play Actor** | [n8n-nodes-google-play-api](https://www.npmjs.com/package/n8n-nodes-google-play-api) | [johnvc](https://apify.com/johnvc) |
 | **Bing Search Actor** | [n8n-nodes-bing-search-api](https://www.npmjs.com/package/n8n-nodes-bing-search-api) | [johnvc](https://apify.com/johnvc) |
 | **Image Similarity Actor** | [n8n-nodes-image-similarity-api](https://www.npmjs.com/package/n8n-nodes-image-similarity-api) | [johnvc](https://apify.com/johnvc) |
+| **Wellfound Jobs Actor** | [n8n-nodes-wellfound-jobs-api](https://www.npmjs.com/package/n8n-nodes-wellfound-jobs-api) | [johnvc](https://apify.com/johnvc) |
 
 Built a node with this template? Open a PR to add it to the list!


### PR DESCRIPTION
Adds two published community nodes to the Published Nodes table.

| Node | npm |
|---|---|
| Wellfound Jobs Actor | [n8n-nodes-wellfound-jobs-api](https://www.npmjs.com/package/n8n-nodes-wellfound-jobs-api) |
| NFX Signal Investor Actor | [n8n-nodes-nfx-signal-investor-api](https://www.npmjs.com/package/n8n-nodes-nfx-signal-investor-api) |

Both are published to npm with SLSA provenance via GitHub Actions trusted publishing, and both pass `@n8n/scan-community-package`. Only the README table is touched.